### PR TITLE
Poistettru rivi using SeamodeREadWrite SeamodeReader.cs tiedostosta

### DIFF
--- a/RaakadataLibrary/SeamodeReader.cs
+++ b/RaakadataLibrary/SeamodeReader.cs
@@ -1,5 +1,4 @@
-﻿using SeaModeReadWrite;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;


### PR DESCRIPTION
Seamodereaderin oli jäänyt väärä usingSeaModeReadWrite lause heti ensimmäiselle riville, joka vinkuin käännösvirhettä. Tämä rivi poistettiin.