### PR TITLE
Tiedoston kirjoitus muutos ja koodin käännös

### DIFF
--- a/Raakadata/MainWindow.xaml
+++ b/Raakadata/MainWindow.xaml
@@ -64,8 +64,8 @@
         </Grid.RowDefinitions>
         <Image Grid.RowSpan="7" Grid.ColumnSpan="24" Source="asets/Seamode.jpg" VerticalAlignment="Top" />
         <Label Grid.Column="0" Grid.Row="8" Content="Path:"   Foreground="White" FontSize="12" Background="#FF303030" />
-        <TextBox x:Name="tbTiedostoPolku" Grid.Column="2" Grid.Row="8" Grid.ColumnSpan="7" Text=""  BorderBrush="#FF303030" />
-        <Button x:Name="BtnHaeTiedostoPolku" Grid.Column="10" Grid.Row="8" Content="Open"  BorderBrush="#FF481616" Foreground="White" FontSize="12" Click="BtnHaeTiedostoPolku_Click" Grid.ColumnSpan="1" >
+        <TextBox x:Name="tbFolderPath" Grid.Column="2" Grid.Row="8" Grid.ColumnSpan="7" Text=""  BorderBrush="#FF303030" />
+        <Button x:Name="BtnSelectFolder" Grid.Column="10" Grid.Row="8" Content="Open"  BorderBrush="#FF481616" Foreground="White" FontSize="12" Click="BtnSelectFolder_Click" Grid.ColumnSpan="1" >
             <Button.Background>
                 <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
                     <GradientStop Color="#FFBABAC3" Offset="0"/>
@@ -73,8 +73,8 @@
                 </LinearGradientBrush>
             </Button.Background>
         </Button>
-        <TextBox x:Name="tbTallennusPolku" Grid.Column="14" Grid.Row="8" Grid.ColumnSpan="7" Text=""  TextChanged="TbKisaTiedostoPolku_TextChanged" BorderBrush="#FF303030"/>
-        <Button x:Name="BtnHaeTallennusPolku" Grid.Column="22" Grid.Row="8" Content="Open"  BorderBrush="#FF481616" Foreground="White" FontSize="12" Click="BtnHaeTallennusPolku_Click" OpacityMask="Black" >
+        <TextBox x:Name="tbSavePath" Grid.Column="14" Grid.Row="8" Grid.ColumnSpan="7" Text=""  TextChanged="TbEventFilePath_TextChanged" BorderBrush="#FF303030"/>
+        <Button x:Name="BtnSelectSavePath" Grid.Column="22" Grid.Row="8" Content="Open"  BorderBrush="#FF481616" Foreground="White" FontSize="12" Click="BtnSelectSavePath_Click" OpacityMask="Black" >
             <Button.Background>
                 <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
                     <GradientStop Color="#FFBABAC3" Offset="0"/>
@@ -82,15 +82,15 @@
                 </LinearGradientBrush>
             </Button.Background>
         </Button>
-        <TextBox x:Name="tbValitutTiedostot" Grid.Column="2" Grid.Row="12" Grid.ColumnSpan="9" Text="" Grid.RowSpan="5" IsReadOnly="True" BorderBrush="#FF303030" />
-        <TextBox x:Name="tbKilpaTiedostoPolku" Grid.Column="14" Grid.Row="12" Grid.ColumnSpan="9" Text="" Grid.RowSpan="5" IsReadOnly="True" BorderBrush="#FF303030" />
+        <TextBox x:Name="tbFilesInFolder" Grid.Column="2" Grid.Row="12" Grid.ColumnSpan="9" Text="" Grid.RowSpan="5" IsReadOnly="True" BorderBrush="#FF303030" />
+        <TextBox x:Name="tbEventFilePath" Grid.Column="14" Grid.Row="12" Grid.ColumnSpan="9" Text="" Grid.RowSpan="5" IsReadOnly="True" BorderBrush="#FF303030" />
         <Label Grid.Column="2" Grid.Row="7" Content="Parce From:"  Grid.ColumnSpan="7"  Foreground="White" FontSize="12" Background="#FF303030"/>
         <Label Grid.Column="14" Grid.Row="7" Content="Parce To:"  Grid.ColumnSpan="7"   Foreground="White" FontSize="12" Background="#FF303030"/>
         <Label Grid.Column="6" Grid.Row="10" Content="End date:"  Grid.ColumnSpan="1"   Foreground="White" FontSize="12" Background="#FF303030"/>
         <Label Grid.Column="0" Grid.Row="10" Content="Start date:"  Grid.ColumnSpan="1"   Foreground="White" FontSize="12" Background="#FF303030"/>
         <Label Grid.Column="14" Grid.Row="10" Content="Output file:"  Grid.ColumnSpan="2"  Foreground="White" FontSize="12" Background="#FF303030"/>
         <Label Grid.Column="0" Grid.Row="17" Content="Log:"  Foreground="White" FontSize="12" Background="#FF303030" />
-        <Button x:Name="BtnLuoKisaTiedosto" Grid.Column="14" Grid.Row="18" Content="Parce raw data"  Grid.ColumnSpan="3" BorderBrush="#FF481616" Foreground="White" FontSize="12"   Click="BtnLuoKisaTiedosto_Click">
+        <Button x:Name="BtnCreateEventFile" Grid.Column="14" Grid.Row="18" Content="Parce raw data"  Grid.ColumnSpan="3" BorderBrush="#FF481616" Foreground="White" FontSize="12"   Click="BtnCreateEventFile_Click">
             <Button.Background>
                 <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
                     <GradientStop Color="#FF939793" Offset="0"/>
@@ -108,15 +108,15 @@
         </Button>
         <TextBox Grid.Column="0"  Grid.Row="7"  Text="i"  ToolTipService.InitialShowDelay="2000" ToolTipService.ShowDuration="20000" ToolTipService.BetweenShowDelay="10000" ToolTip="Chose outputfile location and name. Parce to raw or GPX data to chosen location."  Foreground="Red" Background="#FF303030" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" BorderBrush="#FF303030" SelectionBrush="#FF303030" IsReadOnly="True"/>
         <TextBox Grid.Column="22"  Grid.Row="7"  Text="i"  ToolTipService.InitialShowDelay="2000" ToolTipService.ShowDuration="20000" ToolTipService.BetweenShowDelay="10000" ToolTip="Chose a path to raw data files. Chose start and end date/time to merge data."  Foreground="Red" Background="#FF303030" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" BorderBrush="#FF303030" SelectionBrush="#FF303030" IsReadOnly="True" />
-        <DatePicker x:Name="dpAlkuPvm" Grid.Column="2"  Grid.Row="10"  Grid.ColumnSpan="3" VerticalAlignment="Center" SelectedDateChanged="DpAlkuPvm_SelectedDateChanged" Background="#FF303030"/>
-        <DatePicker x:Name="dpLoppuPvm" Grid.Column="8"  Grid.Row="10" Grid.ColumnSpan="3" VerticalAlignment="Center" Background="#FF303030"/>
-        <TextBox x:Name="textBoxStart" Grid.ColumnSpan="3" Grid.Column="2" MaxLength="8" Grid.Row="11" Text="HH:mm:ss" GotFocus="TbAika_GotFocus" TextChanged="TbAika_TextChanged" LostFocus="TbAika_LostFocus" Background="#FF303030" BorderBrush="#FF303030" Foreground="White" VerticalContentAlignment="Center"/>
+        <DatePicker x:Name="dpEventStartDate" Grid.Column="2"  Grid.Row="10"  Grid.ColumnSpan="3" VerticalAlignment="Center" SelectedDateChanged="DpEventStartDate_SelectedDateChanged" Background="#FF303030"/>
+        <DatePicker x:Name="dpEventEndDate" Grid.Column="8"  Grid.Row="10" Grid.ColumnSpan="3" VerticalAlignment="Center" Background="#FF303030"/>
+        <TextBox x:Name="tbEventStartTime" Grid.ColumnSpan="3" Grid.Column="2" MaxLength="8" Grid.Row="11" Text="HH:mm:ss" GotFocus="TbTime_GotFocus" TextChanged="TbTime_TextChanged" LostFocus="TbTime_LostFocus" Background="#FF303030" BorderBrush="#FF303030" Foreground="White" VerticalContentAlignment="Center"/>
         <Label Grid.Column="0" Grid.Row="11" Content="Start time:"   Grid.ColumnSpan="1"  Foreground="White" FontSize="12" Background="#FF303030" />
         <Label Grid.Column="6" Grid.Row="11" Content="End time:"  Grid.ColumnSpan="1"   Foreground="White" FontSize="12" Background="#FF303030"/>
-        <TextBox x:Name="textBoxEnd" Grid.ColumnSpan="3" Grid.Column="8" MaxLength="8" Grid.Row="11" Text="HH:mm:ss"  TextChanged="TbAika_TextChanged" GotFocus="TbAika_GotFocus" LostFocus="TbAika_LostFocus" Background="#FF303030" BorderBrush="#FF303030" Foreground="White" VerticalContentAlignment="Center"/>
+        <TextBox x:Name="tbEventEndTime" Grid.ColumnSpan="3" Grid.Column="8" MaxLength="8" Grid.Row="11" Text="HH:mm:ss"  TextChanged="TbTime_TextChanged" GotFocus="TbTime_GotFocus" LostFocus="TbTime_LostFocus" Background="#FF303030" BorderBrush="#FF303030" Foreground="White" VerticalContentAlignment="Center"/>
         <TextBox x:Name="BugBox" Grid.ColumnSpan="9" Grid.Column="2"   Grid.Row="17" Grid.RowSpan="2"   VerticalScrollBarVisibility="Auto" TextWrapping="Wrap"  BorderBrush="#FF303030"/>
         <Button Content="tulosta pvm" Grid.Column="12" HorizontalAlignment="Left" Height="38" Grid.Row="15" VerticalAlignment="Top" Width="45" Grid.RowSpan="2" Margin="0,10,0,0" FontSize="8" Click="Button_Click_1" Background="#FF303030"/>
-        <TextBox x:Name="tbKilpailuNimi" Grid.ColumnSpan="7"  TextWrapping="Wrap"   Grid.Column="16"  Grid.Row="10" TextChanged="TbKisaTiedostoPolku_TextChanged"  BorderBrush="#FF303030" VerticalContentAlignment="Center"/>
+        <TextBox x:Name="tbEventName" Grid.ColumnSpan="7"  TextWrapping="Wrap"   Grid.Column="16"  Grid.Row="10" TextChanged="TbEventFilePath_TextChanged"  BorderBrush="#FF303030" VerticalContentAlignment="Center"/>
         <TextBlock x:Name="CopyrightTextBlock" Grid.ColumnSpan="8" Grid.Column="16"  Grid.Row="19" TextWrapping="Wrap" Text="© Oy Baltic Instruments Ab 2014" Foreground="#FFACACAC"  FlowDirection="RightToLeft" UseLayoutRounding="False" VerticalAlignment="Center" HorizontalAlignment="Right"/>
 
         <Border Grid.Column="1" Grid.Row="7" Background="#FF303030"  />

--- a/Raakadata/MainWindow.xaml.cs
+++ b/Raakadata/MainWindow.xaml.cs
@@ -98,7 +98,7 @@ namespace Raakadata
             }
             // tiedostojen luku
             SeamodeReader sr = new SeamodeReader(eventStart, eventEnd);
-            await sr.ReadFilesAsync(tbFolderPath.Text);
+            await sr.ReadAndWriteFilesAsync(tbFolderPath.Text);
             // muuten tulee tyhjä tiedosto
             if (sr.DataRowCount == 0)
             {

--- a/Raakadata/MainWindow.xaml.cs
+++ b/Raakadata/MainWindow.xaml.cs
@@ -17,6 +17,7 @@ using System.Windows.Shapes;
 using Ookii.Dialogs.Wpf;
 using System.Text.RegularExpressions;
 using System.IO;
+using System.Reflection;
 
 namespace Raakadata
 {
@@ -209,7 +210,14 @@ namespace Raakadata
 
         private void Button_Click_1(object sender, RoutedEventArgs e)
         {
-            // tämä oli Artolla testausta varten?
+            string s = System.IO.Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName);
+            //string s = Directory.GetParent(Assembly.GetExecutingAssembly().Location).ToString();
+            //string s = System.IO.Path.GetDirectoryName(Environment.GetCommandLineArgs()[0]);
+            if (s.EndsWith("prg"))
+            {
+                s.Replace("prg", "dat");
+            }
+            MessageBox.Show(s);
         }
 
         private void DpEventStartDate_SelectedDateChanged(object sender, SelectionChangedEventArgs e) 

--- a/Raakadata/MainWindow.xaml.cs
+++ b/Raakadata/MainWindow.xaml.cs
@@ -215,7 +215,7 @@ namespace Raakadata
             //string s = System.IO.Path.GetDirectoryName(Environment.GetCommandLineArgs()[0]);
             if (s.EndsWith("prg"))
             {
-                s.Replace("prg", "dat");
+                s = s.Replace("prg", "dat");
             }
             MessageBox.Show(s);
         }

--- a/Raakadata/MainWindow.xaml.cs
+++ b/Raakadata/MainWindow.xaml.cs
@@ -60,7 +60,7 @@ namespace Raakadata
                 tbTallennusPolku.Text = fd.SelectedPath;
         }
 
-        private void BtnLuoKisaTiedosto_Click(object sender, RoutedEventArgs e)
+        private async void BtnLuoKisaTiedosto_Click(object sender, RoutedEventArgs e)
         {
             // jotta ei tapahdu tupla klikkausta.
             BtnLuoKisaTiedosto.IsEnabled = false;
@@ -97,10 +97,8 @@ namespace Raakadata
             }
             // tiedostojen luku
             SeamodeReader sr = new SeamodeReader(alku, loppu);
-            foreach (string tiedosto in sr.HaeTiedostot(tbTiedostoPolku.Text))
-            {
-                sr.LueTiedosto(tiedosto);
-            }
+            var t = Task.Run(() => sr.HaeTiedostot(tbTiedostoPolku.Text));
+            t.Wait();
             // muuten tulee tyhjä tiedosto
             if (sr.DataRowCount == 0)
             {

--- a/Raakadata/MainWindow.xaml.cs
+++ b/Raakadata/MainWindow.xaml.cs
@@ -97,8 +97,7 @@ namespace Raakadata
             }
             // tiedostojen luku
             SeamodeReader sr = new SeamodeReader(alku, loppu);
-            var t = Task.Run(() => sr.HaeTiedostot(tbTiedostoPolku.Text));
-            t.Wait();
+            await sr.ReadFilesAsync(tbTiedostoPolku.Text);
             // muuten tulee tyhjä tiedosto
             if (sr.DataRowCount == 0)
             {

--- a/Raakadata/MainWindow.xaml.cs
+++ b/Raakadata/MainWindow.xaml.cs
@@ -16,6 +16,7 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using Ookii.Dialogs.Wpf;
 using System.Text.RegularExpressions;
+using System.IO;
 
 namespace Raakadata
 {
@@ -108,8 +109,7 @@ namespace Raakadata
                 return;
             }
             // kisatiedoston luonti
-            SeamodeWriter sw = new SeamodeWriter() { OutFile = tbKilpaTiedostoPolku.Text };
-            sw.Kirjoita(sr.Rivit);
+            File.Move(sr.TmpFile, tbKilpaTiedostoPolku.Text);
             MessageBox.Show($"File {tbKilpaTiedostoPolku.Text} was created.");
             if (sr.ReaderErrors.Count > 0)
             {

--- a/Raakadata/MainWindow.xaml.cs
+++ b/Raakadata/MainWindow.xaml.cs
@@ -39,7 +39,7 @@ namespace Raakadata
         }
 
         private void ListaaTiedostot() =>
-            tbValitutTiedostot.Text = string.Join("\r\n", SeamodeReader.HaeTiedostotListaan(tbTiedostoPolku.Text));
+            tbValitutTiedostot.Text = string.Join("\r\n", SeamodeReader.FetchFilesToList(tbTiedostoPolku.Text));
 
         private void BtnHaeTiedostoPolku_Click(object sender, RoutedEventArgs e)
         {
@@ -108,9 +108,9 @@ namespace Raakadata
             // kisatiedoston luonti
             File.Move(sr.TmpFile, tbKilpaTiedostoPolku.Text);
             MessageBox.Show($"File {tbKilpaTiedostoPolku.Text} was created.");
-            if (sr.ReaderErrors.Count > 0)
+            if (sr.DataRowErrors.Count > 0)
             {
-                MessageBox.Show($"{string.Join("\n", sr.ReaderErrors)}");
+                MessageBox.Show($"{string.Join("\n", sr.DataRowErrors)}");
             }
             BtnLuoKisaTiedosto.IsEnabled = true;
             // syötetyt arvot tyhjennetään

--- a/RaakadataLibrary/SeamodeReader.cs
+++ b/RaakadataLibrary/SeamodeReader.cs
@@ -76,7 +76,7 @@ namespace RaakadataLibrary
         public void ReadDataFile(string filePath)
         {
             string headerRowPattern = "^Date_PC(.*)Time_PC";
-            string[] seperator = { ";" };
+            string[] separator = { ";" };
             bool headerRowsFoundInCurrentFile = false;
             int rowNum = 1;
             using (StreamWriter sw = File.AppendText(TmpFile))
@@ -89,7 +89,7 @@ namespace RaakadataLibrary
                     if (headerRowsFoundInCurrentFile)
                     {
                         // Tarkistetaan sopiiko aika -> string splitillä haetaan aika
-                        string[] rowValues = row.Split(seperator, StringSplitOptions.RemoveEmptyEntries);
+                        string[] rowValues = row.Split(separator, StringSplitOptions.RemoveEmptyEntries);
                         if (TimeValidation(rowValues, rowNum))
                         {
                             if (rowValues.Length == columnCount)
@@ -119,10 +119,10 @@ namespace RaakadataLibrary
                         Match headerMatch = Regex.Match(row, headerRowPattern);
                         if (headerMatch.Success)
                         {
-                            columnCount = row.Split(seperator, StringSplitOptions.RemoveEmptyEntries).Length;
+                            columnCount = row.Split(separator, StringSplitOptions.RemoveEmptyEntries).Length;
                             headerRowsFound = true;
                             headerRowsFoundInCurrentFile = true;
-                            seperator[0] = headerMatch.Groups[1].ToString();
+                            separator[0] = headerMatch.Groups[1].ToString();
                         }
                         if (!headerRowsFoundInCurrentFile)
                             validFile = FileValidation(rowNum, row, validFile);
@@ -134,12 +134,14 @@ namespace RaakadataLibrary
                         Match headerMatch = Regex.Match(row, headerRowPattern);
                         if (headerMatch.Success)
                         {
-                            seperator[0] = headerMatch.Groups[1].ToString();
+                            separator[0] = headerMatch.Groups[1].ToString();
                             headerRowsFoundInCurrentFile = true;
                         }
                     }
                     rowNum++;
                 }
+                if (!validFile)
+                    DataRowErrors.Add($"There was something wrong with the xml section in file:\n{filePath}");
             }
         }
 

--- a/RaakadataLibrary/SeamodeReader.cs
+++ b/RaakadataLibrary/SeamodeReader.cs
@@ -23,6 +23,8 @@ namespace RaakadataLibrary
             ReaderErrors = new List<string>();
         }
 
+        public async Task ReadFilesAsync(string path) => await Task.Run(() => HaeTiedostot(path));
+
         private bool IsOtsikkoTehty = false;
         private bool headerRowsWritten = false;
         private readonly DateTime startTime;
@@ -59,7 +61,6 @@ namespace RaakadataLibrary
 
         public void HaeTiedostot(string polku)
         {
-            List<string> filePaths = new List<string>();
             // Muuta seuraavat syötteeksi tai jostain configista haettavaksi
             DirectoryInfo di = new DirectoryInfo(polku);
             string esimerkki = "SeaMODE_20190928_112953.csv";
@@ -67,11 +68,7 @@ namespace RaakadataLibrary
             foreach (var fi in di.GetFiles())
             {
                 if ((Regex.IsMatch(fi.Name, startPattern) || Regex.IsMatch(fi.Name, endPattern)) && Regex.IsMatch(fi.Name, ".csv$") && fi.Name.Length == pit)
-                    filePaths.Add(fi.FullName);
-            }
-            foreach (string filePath in filePaths)
-            {
-                LueTiedosto(filePath);
+                    LueTiedosto(fi.FullName);
             }
         }
         // Haetaan rivit yhdelle tiedostolle

--- a/RaakadataLibrary/SeamodeReader.cs
+++ b/RaakadataLibrary/SeamodeReader.cs
@@ -12,20 +12,18 @@ namespace RaakadataLibrary
     public class SeamodeReader
     {
         // Annetaan start date ja time 
-        public SeamodeReader(DateTime aloitusAika, DateTime lopetusAika)
+        public SeamodeReader(DateTime _startTime, DateTime _endTime)
         {
-            startTime = aloitusAika;
-            endTime = lopetusAika;
-            string pvmFormator = string.Format("yyyyMMdd");
-            startPattern = startPattern_c + startTime.ToString(pvmFormator);
-            endPattern = startPattern_c + endTime.ToString(pvmFormator);
+            startTime = _startTime;
+            endTime = _endTime;
+            string dateFormat = string.Format("yyyyMMdd");
+            startPattern = startPattern_c + startTime.ToString(dateFormat);
+            endPattern = startPattern_c + endTime.ToString(dateFormat);
             headerRows = new List<string>();
-            ReaderErrors = new List<string>();
+            DataRowErrors = new List<string>();
         }
 
-        public async Task ReadFilesAsync(string path) => await Task.Run(() => HaeTiedostot(path));
-
-        private bool IsOtsikkoTehty = false;
+        private bool headerRowsFound = false;
         private bool headerRowsWritten = false;
         private readonly DateTime startTime;
         private readonly DateTime endTime;
@@ -36,105 +34,108 @@ namespace RaakadataLibrary
         private int columnCount;
         // liian suuri ajanmuutos = virhe, mutta missä on raja?
         private TimeSpan maximumTimeStep = TimeSpan.FromSeconds(1);
-        private DateTime? previousTime = null;
+        private DateTime? prevEventTime = null;
         private readonly List<string> headerRows;
 
         public string TmpFile = Path.GetTempFileName();
         public List<GpxLine> gpxLines { get; set; }
         public int DataRowCount { get; private set; } = 0;
-        public List<string> ReaderErrors { get; private set; }
+        public List<string> DataRowErrors { get; private set; }
+
+        public async Task ReadFilesAsync(string path) => await Task.Run(() => FetchFilesToRead(path));
+
         // tämä on vain tiedostojen listausta wpf:ää varten.
-        public static List<string> HaeTiedostotListaan(string polku)
+        public static List<string> FetchFilesToList(string path)
         {
-            List<string> filekset = new List<string>();
-            DirectoryInfo di = new DirectoryInfo(polku);
-            string esimerkki = "SeaMODE_20190928_112953.csv";
-            int pit = esimerkki.Length;
+            List<string> files = new List<string>();
+            DirectoryInfo di = new DirectoryInfo(path);
+            string example = "SeaMODE_20190928_112953.csv";
+            int len = example.Length;
             foreach (var fi in di.GetFiles())
             {
-                if (Regex.IsMatch(fi.Name, "^SeaMODE_") && Regex.IsMatch(fi.Name, ".csv$") && fi.Name.Length == pit)
-                    filekset.Add(fi.FullName);
+                if (Regex.IsMatch(fi.Name, "^SeaMODE_") && Regex.IsMatch(fi.Name, ".csv$") && fi.Name.Length == len)
+                    files.Add(fi.FullName);
             }
 
-            return filekset;
+            return files;
         }
 
-        public void HaeTiedostot(string polku)
+        public void FetchFilesToRead(string directoryPath)
         {
             // Muuta seuraavat syötteeksi tai jostain configista haettavaksi
-            DirectoryInfo di = new DirectoryInfo(polku);
-            string esimerkki = "SeaMODE_20190928_112953.csv";
-            int pit = esimerkki.Length;
+            DirectoryInfo di = new DirectoryInfo(directoryPath);
+            string example = "SeaMODE_20190928_112953.csv";
+            int len = example.Length;
             foreach (var fi in di.GetFiles())
             {
-                if ((Regex.IsMatch(fi.Name, startPattern) || Regex.IsMatch(fi.Name, endPattern)) && Regex.IsMatch(fi.Name, ".csv$") && fi.Name.Length == pit)
-                    LueTiedosto(fi.FullName);
+                if ((Regex.IsMatch(fi.Name, startPattern) || Regex.IsMatch(fi.Name, endPattern)) && Regex.IsMatch(fi.Name, ".csv$") && fi.Name.Length == len)
+                    ReadDataFile(fi.FullName);
             }
         }
         // Haetaan rivit yhdelle tiedostolle
-        public void LueTiedosto(string fileName)
+        public void ReadDataFile(string filePath)
         {
-            string riviOtsikkoPattern = "^Date_PC(.*)Time_PC";
+            string headerRowPattern = "^Date_PC(.*)Time_PC";
             string[] seperator = { ";" };
-            bool isOtsikkoOhi = false;
+            bool headerRowsFoundInCurrentFile = false;
             int rowNum = 1;
             using (StreamWriter sw = File.AppendText(TmpFile))
-            using (StreamReader sr = File.OpenText(fileName))
+            using (StreamReader sr = File.OpenText(filePath))
             {
-                string luettu = "";
+                string row = "";
                 bool validFile = true;
-                while ((luettu = sr.ReadLine()) != null && validFile)
+                while ((row = sr.ReadLine()) != null && validFile)
                 {
-                    if (isOtsikkoOhi)
+                    if (headerRowsFoundInCurrentFile)
                     {
                         // Tarkistetaan sopiiko aika -> string splitillä haetaan aika
-                        string[] rowValues = luettu.Split(seperator, StringSplitOptions.RemoveEmptyEntries);
-                        if (TarkistaAika(rowValues, rowNum))
+                        string[] rowValues = row.Split(seperator, StringSplitOptions.RemoveEmptyEntries);
+                        if (TimeValidation(rowValues, rowNum))
                         {
                             if (rowValues.Length == columnCount)
                             {
                                 DataRowCount++;
                                 if (headerRowsWritten)
-                                    sw.WriteLine(luettu);
+                                    sw.WriteLine(row);
                                 else
                                 {
                                     foreach (string line in headerRows)
                                     {
                                         sw.WriteLine(line);
                                     }
-                                    sw.WriteLine(luettu);
+                                    sw.WriteLine(row);
                                     headerRows.Clear();
                                     headerRows.TrimExcess();
                                     headerRowsWritten = true;
                                 }
                             }
                             else
-                                ReaderErrors.Add($"There was missing data on row {rowNum}. The row was disregarded.");
+                                DataRowErrors.Add($"There was missing data on row {rowNum}. The row was disregarded.");
                         }
                     }
                     // Otsikkotiedot vain kerran
-                    if (!IsOtsikkoTehty && !isOtsikkoOhi)
+                    if (!headerRowsFound && !headerRowsFoundInCurrentFile)
                     {
-                        Match headerMatch = Regex.Match(luettu, riviOtsikkoPattern);
+                        Match headerMatch = Regex.Match(row, headerRowPattern);
                         if (headerMatch.Success)
                         {
-                            columnCount = luettu.Split(seperator, StringSplitOptions.RemoveEmptyEntries).Length;
-                            IsOtsikkoTehty = true;
-                            isOtsikkoOhi = true;
+                            columnCount = row.Split(seperator, StringSplitOptions.RemoveEmptyEntries).Length;
+                            headerRowsFound = true;
+                            headerRowsFoundInCurrentFile = true;
                             seperator[0] = headerMatch.Groups[1].ToString();
                         }
-                        if (!isOtsikkoOhi)
-                            validFile = FileValidation(rowNum, luettu, validFile);
-                        headerRows.Add(luettu);
+                        if (!headerRowsFoundInCurrentFile)
+                            validFile = FileValidation(rowNum, row, validFile);
+                        headerRows.Add(row);
                     }
                     // Otsikko luettu myös ensimmäisen tiedoston jälkeen.
-                    if (IsOtsikkoTehty && !isOtsikkoOhi)
+                    if (headerRowsFound && !headerRowsFoundInCurrentFile)
                     {
-                        Match headerMatch = Regex.Match(luettu, riviOtsikkoPattern);
+                        Match headerMatch = Regex.Match(row, headerRowPattern);
                         if (headerMatch.Success)
                         {
                             seperator[0] = headerMatch.Groups[1].ToString();
-                            isOtsikkoOhi = true;
+                            headerRowsFoundInCurrentFile = true;
                         }
                     }
                     rowNum++;
@@ -145,6 +146,7 @@ namespace RaakadataLibrary
         private static bool FileValidation(int rowNum, string row, bool validFile)
         {
             // testaus näyttääkö tiedosto oikealta, jos ei muistiin kirjoittaminen lopetetaan.
+            // tarvitaanko tätä enää?
             switch (rowNum)
             {
                 case 1:
@@ -211,19 +213,19 @@ namespace RaakadataLibrary
             gpxLines.Add(gpxLine);
         }
         // Tarkistetaan aika
-        private bool TarkistaAika(string[] values, int rowNum)
+        private bool TimeValidation(string[] values, int rowNum)
         {
             // ensimmäisessä alkiossa pvm muodossa pp.kk.vvvv ja toisessa aika hh:mm:ss.nnn
-            DateTime tapahtumaAika = DateTime.ParseExact(values[0] + " " + values[1], "dd.MM.yyyy HH:mm:ss.fff", cultureInfo);
-            if (tapahtumaAika >= startTime && tapahtumaAika <= endTime)
+            DateTime eventTime = DateTime.ParseExact(values[0] + " " + values[1], "dd.MM.yyyy HH:mm:ss.fff", cultureInfo);
+            if (eventTime >= startTime && eventTime <= endTime)
             {
-                if (previousTime != null && tapahtumaAika - previousTime > maximumTimeStep)
+                if (prevEventTime != null && eventTime - prevEventTime > maximumTimeStep)
                 {
-                    ReaderErrors.Add($"There was a large time difference at row {rowNum}.");
-                    previousTime = tapahtumaAika;
+                    DataRowErrors.Add($"There was a large time difference at row {rowNum}.");
+                    prevEventTime = eventTime;
                     return false;
                 }
-                previousTime = tapahtumaAika;
+                prevEventTime = eventTime;
                 return true;
             }
             else

--- a/RaakadataLibrary/SeamodeReader.cs
+++ b/RaakadataLibrary/SeamodeReader.cs
@@ -77,7 +77,7 @@ namespace RaakadataLibrary
         {
             string headerRowPattern = "^Date_PC(.*)Time_PC";
             string[] separator = { ";" };
-            bool headerRowsFoundInCurrentFile = false;
+            bool headerRowsFoundCurrentFile = false;
             int rowNum = 1;
             using (StreamWriter sw = File.AppendText(TmpFile))
             using (StreamReader sr = File.OpenText(filePath))
@@ -86,7 +86,7 @@ namespace RaakadataLibrary
                 bool validFile = true;
                 while ((row = sr.ReadLine()) != null && validFile)
                 {
-                    if (headerRowsFoundInCurrentFile)
+                    if (headerRowsFoundCurrentFile)
                     {
                         // Tarkistetaan sopiiko aika -> string splitillä haetaan aika
                         string[] rowValues = row.Split(separator, StringSplitOptions.RemoveEmptyEntries);
@@ -114,28 +114,28 @@ namespace RaakadataLibrary
                         }
                     }
                     // Otsikkotiedot vain kerran
-                    if (!headerRowsFound && !headerRowsFoundInCurrentFile)
+                    else if (!headerRowsFound && !headerRowsFoundCurrentFile)
                     {
                         Match headerMatch = Regex.Match(row, headerRowPattern);
                         if (headerMatch.Success)
                         {
                             columnCount = row.Split(separator, StringSplitOptions.RemoveEmptyEntries).Length;
                             headerRowsFound = true;
-                            headerRowsFoundInCurrentFile = true;
+                            headerRowsFoundCurrentFile = true;
                             separator[0] = headerMatch.Groups[1].ToString();
                         }
-                        if (!headerRowsFoundInCurrentFile)
+                        else
                             validFile = FileValidation(rowNum, row, validFile);
                         headerRows.Add(row);
                     }
                     // Otsikko luettu myös ensimmäisen tiedoston jälkeen.
-                    if (headerRowsFound && !headerRowsFoundInCurrentFile)
+                    else if (headerRowsFound && !headerRowsFoundCurrentFile)
                     {
                         Match headerMatch = Regex.Match(row, headerRowPattern);
                         if (headerMatch.Success)
                         {
                             separator[0] = headerMatch.Groups[1].ToString();
-                            headerRowsFoundInCurrentFile = true;
+                            headerRowsFoundCurrentFile = true;
                         }
                     }
                     rowNum++;
@@ -219,19 +219,7 @@ namespace RaakadataLibrary
         {
             // ensimmäisessä alkiossa pvm muodossa pp.kk.vvvv ja toisessa aika hh:mm:ss.nnn
             DateTime eventTime = DateTime.ParseExact(values[0] + " " + values[1], "dd.MM.yyyy HH:mm:ss.fff", cultureInfo);
-            if (eventTime >= startTime && eventTime <= endTime)
-            {
-                //if (prevEventTime != null && eventTime - prevEventTime > maximumTimeStep)
-                //{
-                //    DataRowErrors.Add($"There was a large time difference at row {rowNum}.");
-                //    prevEventTime = eventTime;
-                //    return false;
-                //}
-                //prevEventTime = eventTime;
-                return true;
-            }
-            else
-                return false;
+            return (eventTime >= startTime && eventTime <= endTime) ? true : false;
         }
 
         // Tarkistetaan aika

--- a/RaakadataLibrary/SeamodeReader.cs
+++ b/RaakadataLibrary/SeamodeReader.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
@@ -31,7 +32,6 @@ namespace RaakadataLibrary
         private readonly string startPattern;
         private readonly string endPattern;
         private readonly CultureInfo cultureInfo = new CultureInfo("fi-FI");
-        private bool dataColumnsCounted = false;
         private int columnCount;
         // liian suuri ajanmuutos = virhe, mutta missä on raja?
         private TimeSpan maximumTimeStep = TimeSpan.FromSeconds(1);
@@ -96,22 +96,21 @@ namespace RaakadataLibrary
                         string[] rowValues = row.Split(separator, StringSplitOptions.RemoveEmptyEntries);
                         if (TimeValidation(rowValues, rowNum))
                         {
+                            if (!headersWritten)
+                            {
+                                foreach (string line in headerRows)
+                                {
+                                    sw.WriteLine(line);
+                                }
+                                columnCount = headerRows.Last().Split(separator, StringSplitOptions.RemoveEmptyEntries).Length;
+                                headerRows.Clear();
+                                headerRows.TrimExcess();
+                                headersWritten = true;
+                            }
                             if (rowValues.Length == columnCount)
                             {
                                 DataRowCount++;
-                                if (headersWritten)
-                                    sw.WriteLine(row);
-                                else
-                                {
-                                    foreach (string line in headerRows)
-                                    {
-                                        sw.WriteLine(line);
-                                    }
-                                    sw.WriteLine(row);
-                                    headerRows.Clear();
-                                    headerRows.TrimExcess();
-                                    headersWritten = true;
-                                }
+                                sw.WriteLine(row);
                             }
                             else
                                 DataRowErrors.Add($"There was missing data on row {rowNum}. The row was disregarded.");
@@ -152,11 +151,6 @@ namespace RaakadataLibrary
                     {
                         separator[0] = headerMatch.Groups[1].ToString();
                         headersFound = true;
-                        if (!dataColumnsCounted)
-                        {
-                            columnCount = row.Split(separator, StringSplitOptions.RemoveEmptyEntries).Length;
-                            dataColumnsCounted = true;
-                        }
                     }
                     break;
             }

--- a/RaakadataLibrary/SeamodeReader.cs
+++ b/RaakadataLibrary/SeamodeReader.cs
@@ -77,6 +77,7 @@ namespace RaakadataLibrary
             string riviOtsikkoPattern = "^Date_PC(.*)Time_PC";
             string[] seperator = { ";" };
             bool isOtsikkoOhi = false;
+            int rowNum = 1;
             using (StreamReader sr = File.OpenText(fileName))
             {
                 string luettu = "";
@@ -86,7 +87,7 @@ namespace RaakadataLibrary
                     {
                         // Tarkistetaan sopiiko aika -> string splitillä haetaan aika
                         string[] rowValues = luettu.Split(seperator, StringSplitOptions.RemoveEmptyEntries);
-                        if (TarkistaAika(rowValues))
+                        if (TarkistaAika(rowValues, rowNum))
                         {
                             if (rowValues.Length == columnCount)
                             {
@@ -94,7 +95,7 @@ namespace RaakadataLibrary
                                 Rivit.Add(luettu);
                             }
                             else
-                                ReaderErrors.Add($"There was missing data on row {Rivit.Count}. The row was disregarded.");
+                                ReaderErrors.Add($"There was missing data on row {rowNum}. The row was disregarded.");
                         }
                     }
                     // Otsikkotiedot vain kerran
@@ -120,6 +121,7 @@ namespace RaakadataLibrary
                             isOtsikkoOhi = true;
                         }
                     }
+                    rowNum++;
                 }
             }
         }
@@ -170,15 +172,15 @@ namespace RaakadataLibrary
             gpxLines.Add(gpxLine);
         }
         // Tarkistetaan aika
-        private bool TarkistaAika(string[] arvot)
+        private bool TarkistaAika(string[] values, int rowNum)
         {
             // ensimmäisessä alkiossa pvm muodossa pp.kk.vvvv ja toisessa aika hh:mm:ss.nnn
-            DateTime tapahtumaAika = DateTime.ParseExact(arvot[0] + " " + arvot[1], "dd.MM.yyyy HH:mm:ss.fff", cultureInfo);
+            DateTime tapahtumaAika = DateTime.ParseExact(values[0] + " " + values[1], "dd.MM.yyyy HH:mm:ss.fff", cultureInfo);
             if (tapahtumaAika >= startTime && tapahtumaAika <= endTime)
             {
                 if (previousTime != null && tapahtumaAika - previousTime > maximumTimeStep)
                 {
-                    ReaderErrors.Add($"There was a large time difference at row {Rivit.Count}. The row was disregarded.");
+                    ReaderErrors.Add($"There was a large time difference at row {rowNum}. The row was disregarded.");
                     previousTime = tapahtumaAika;
                     return false;
                 }

--- a/RaakadataLibrary/SeamodeReader.cs
+++ b/RaakadataLibrary/SeamodeReader.cs
@@ -19,7 +19,7 @@ namespace RaakadataLibrary
             string dateFormat = string.Format("yyyyMMdd");
             startPattern = startPattern_c + startTime.ToString(dateFormat);
             endPattern = startPattern_c + endTime.ToString(dateFormat);
-            headerRows = new List<string>();
+            //headerRows = new List<string>();
             DataRowErrors = new List<string>();
         }
 
@@ -36,7 +36,7 @@ namespace RaakadataLibrary
         // liian suuri ajanmuutos = virhe, mutta missä on raja?
         private TimeSpan maximumTimeStep = TimeSpan.FromSeconds(1);
         private DateTime? prevEventTime = null;
-        private readonly List<string> headerRows;
+        //private readonly List<string> headerRows;
         private readonly string headerRowPattern = "^Date_PC(.*)Time_PC";
 
         public string TmpFile = Path.GetTempFileName();
@@ -80,13 +80,14 @@ namespace RaakadataLibrary
         public void ReadDataFile(string filePath)
         {
             string[] separator = { ";" };
+            bool validFile = true;
             bool headerRowsFoundCurrentFile = false;
+            List<string> headerRows = new List<string>();
             int rowNum = 1;
             using (StreamWriter sw = File.AppendText(TmpFile))
             using (StreamReader sr = File.OpenText(filePath))
             {
                 string row = "";
-                bool validFile = true;
                 while ((row = sr.ReadLine()) != null && validFile && !pastEnd)
                 {
                     if (headerRowsFoundCurrentFile)
@@ -117,7 +118,7 @@ namespace RaakadataLibrary
                         }
                     }
                     else
-                        FileValidation(rowNum, row, ref validFile, ref headerRowsFoundCurrentFile, ref separator);
+                        FileValidation(headerRows, rowNum, row, ref validFile, ref headerRowsFoundCurrentFile, ref separator);
                     rowNum++;
                 }
                 if (!validFile)
@@ -126,6 +127,7 @@ namespace RaakadataLibrary
         }
 
         private void FileValidation(
+            List<string> headerRows,
             int rowNum,
             string row,
             ref bool validFile,

--- a/RaakadataLibrary/SeamodeReader.cs
+++ b/RaakadataLibrary/SeamodeReader.cs
@@ -94,6 +94,7 @@ namespace RaakadataLibrary
                             {
                                 DataRowCount++;
                                 Rivit.Add(luettu);
+                                // tähän write luettu
                             }
                             else
                                 ReaderErrors.Add($"There was missing data on row {rowNum}. The row was disregarded.");
@@ -109,6 +110,7 @@ namespace RaakadataLibrary
                             IsOtsikkoTehty = true;
                             isOtsikkoOhi = true;
                             seperator[0] = headerMatch.Groups[1].ToString();
+                            // tähän writealltext rivit + write luettu?
                         }
                         if (!isOtsikkoOhi)
                             validFile = FileValidation(rowNum, luettu, validFile);

--- a/RaakadataLibrary/SeamodeReader.cs
+++ b/RaakadataLibrary/SeamodeReader.cs
@@ -180,7 +180,7 @@ namespace RaakadataLibrary
                 while ((luettu = sr.ReadLine()) != null)
                 {
                     string[] rowValues = luettu.Split(seperator, StringSplitOptions.RemoveEmptyEntries);
-                    if (isOtsikkoOhi && TarkistaAika(rowValues))
+                    if (isOtsikkoOhi && TimeValidation(rowValues))
                     {
                         //Nullable<DateTime> prevDateTime = null;
                         DateTime newDateTime;
@@ -214,6 +214,26 @@ namespace RaakadataLibrary
             gpxLine.setLongitude(arvot[27]);
             gpxLines.Add(gpxLine);
         }
+
+        private bool TimeValidation(string[] values)
+        {
+            // ensimmäisessä alkiossa pvm muodossa pp.kk.vvvv ja toisessa aika hh:mm:ss.nnn
+            DateTime eventTime = DateTime.ParseExact(values[0] + " " + values[1], "dd.MM.yyyy HH:mm:ss.fff", cultureInfo);
+            if (eventTime >= startTime && eventTime <= endTime)
+            {
+                //if (prevEventTime != null && eventTime - prevEventTime > maximumTimeStep)
+                //{
+                //    DataRowErrors.Add($"There was a large time difference at row {rowNum}.");
+                //    prevEventTime = eventTime;
+                //    return false;
+                //}
+                //prevEventTime = eventTime;
+                return true;
+            }
+            else
+                return false;
+        }
+
         // Tarkistetaan aika
         private bool TimeValidation(string[] values, int rowNum)
         {
@@ -233,6 +253,7 @@ namespace RaakadataLibrary
             else
                 return false;
         }
+
         private DateTime muodostoGpxAika(string luettuRivi)
         {
             string[] arvot = luettuRivi.Split(';');

--- a/RaakadataLibrary/SeamodeReader.cs
+++ b/RaakadataLibrary/SeamodeReader.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using System.Windows;
 
 namespace RaakadataLibrary
@@ -56,9 +57,9 @@ namespace RaakadataLibrary
             return filekset;
         }
 
-        public List<string> HaeTiedostot(string polku)
+        public void HaeTiedostot(string polku)
         {
-            List<string> filekset = new List<string>();
+            List<string> filePaths = new List<string>();
             // Muuta seuraavat syötteeksi tai jostain configista haettavaksi
             DirectoryInfo di = new DirectoryInfo(polku);
             string esimerkki = "SeaMODE_20190928_112953.csv";
@@ -66,10 +67,12 @@ namespace RaakadataLibrary
             foreach (var fi in di.GetFiles())
             {
                 if ((Regex.IsMatch(fi.Name, startPattern) || Regex.IsMatch(fi.Name, endPattern)) && Regex.IsMatch(fi.Name, ".csv$") && fi.Name.Length == pit)
-                    filekset.Add(fi.FullName);
+                    filePaths.Add(fi.FullName);
             }
-
-            return filekset;
+            foreach (string filePath in filePaths)
+            {
+                LueTiedosto(filePath);
+            }
         }
         // Haetaan rivit yhdelle tiedostolle
         public void LueTiedosto(string fileName)
@@ -142,21 +145,21 @@ namespace RaakadataLibrary
             }
         }
 
-        private static bool FileValidation(int rowNum, string luettu, bool validFile)
+        private static bool FileValidation(int rowNum, string row, bool validFile)
         {
             // testaus näyttääkö tiedosto oikealta, jos ei muistiin kirjoittaminen lopetetaan.
             switch (rowNum)
             {
                 case 1:
-                    if (!luettu.StartsWith("<?xml version="))
+                    if (!row.StartsWith("<?xml version="))
                         validFile = false;
                     break;
                 case 2:
-                    if (!luettu.StartsWith("<CalibrationData>"))
+                    if (!row.StartsWith("<CalibrationData>"))
                         validFile = false;
                     break;
                 default:
-                    if (!Regex.IsMatch(luettu, @"^\s+<") && !luettu.StartsWith("</CalibrationData>"))
+                    if (!Regex.IsMatch(row, @"^\s+<") && !row.StartsWith("</CalibrationData>"))
                         validFile = false;
                     break;
             }


### PR DESCRIPTION
Yritin tehdä metodien ja muuttujien nimistä kuvaavia. Feedback is welcome!

Tiedoston lukeva metodi ReadAndWriteDataFile (ennen: LueTiedosto) nyt myös kirjoittaa rivin kerrallaan, otsikot kirjoitetaan ennen ensimmäistä löydettyä datariviä, Windowsin tekemään temp tiedostoon. Jos DataRowCount, eli kuinka monta riviä dataa löytyi, on suurempi kuin 0, temp tiedosto siirtyy dat kansioon ja nimi muunnetaan käyttäjän määrittämäksi. Jos dataa ei löydy tiedosto jää tempiksi ja Windows hoitaa sen. SeamodeWriter ei ole enää käytössä.

Lisäsin FileValidation metodin. Se tarkistaa vastaavatko otsikkorivit oletusta, jos ei, tiedoston luku lopetetaan. Metodi asettaan separatorin ja kun otsikko on löydetty.

Lisäsin ReadAndWriteFilesAsync ja ForeachFileIn metodit, nämä poistaa käyttöliittymän lukkiutumisen luennan ja kirjoituksen aikana. 